### PR TITLE
Step 5 - Show Feedback

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -5,15 +5,31 @@ import { Guess } from "../model/guess";
 import { NUM_OF_GUESSES_ALLOWED } from "../constants";
 import { words } from "../data";
 import { checkGuess, pickAnswer } from "../utils";
+import { Alert, Snackbar } from "@mui/material";
+
+type AlertState = {
+  severity: "success" | "warning" | "info";
+  message: string;
+} | null;
 
 function Game() {
   const [answer, setAnswer] = React.useState<string>(() => pickAnswer(words));
   const [currentGuesses, setCurrentGuesses] = React.useState<Guess[]>([]);
   const [isPlaying, setIsPlaying] = React.useState<boolean>(true);
+  const [alert, setAlert] = React.useState<AlertState>(null);
+
+  function restartGame() {
+    if (alert?.severity === "info") setAlert(null);
+    else {
+      setAlert({
+        severity: "info",
+        message: "Refresh the page to play again.",
+      });
+    }
+  }
 
   function addNewGuess(guess: string) {
     if (!isPlaying) {
-      alert("Refresh the page to play again.");
       return;
     }
 
@@ -30,19 +46,41 @@ function Game() {
     const isCorrect = statusArray.every((status) => status === "correct");
     if (isCorrect) {
       setIsPlaying(false);
-      console.log("You've guessed the word!");
+      setAlert({
+        severity: "success",
+        message: "Congrats! You've guessed the word!",
+      });
     }
 
     if (!isCorrect && currentGuesses.length === NUM_OF_GUESSES_ALLOWED - 1) {
       setIsPlaying(false);
-      console.log("You've reached the maximum number of guesses allowed.");
+      setAlert({
+        severity: "warning",
+        message: `No more guesses left.\nThe answer was ${answer}.`,
+      });
     }
   }
 
   return (
     <div className="game-wrapper">
       <GuessList currentGuesses={currentGuesses} />
-      <GuessInput addNewGuess={addNewGuess} />
+      <GuessInput addNewGuess={addNewGuess} isPlaying={isPlaying} />
+      {alert && (
+        <Snackbar
+          anchorOrigin={{ vertical: "top", horizontal: "center" }}
+          open={true}
+          onClose={restartGame}
+        >
+          <Alert
+            onClose={restartGame}
+            severity={alert?.severity}
+            variant="filled"
+            sx={{ width: "100%" }}
+          >
+            {alert?.message}
+          </Alert>
+        </Snackbar>
+      )}
     </div>
   );
 }

--- a/src/components/GuessInput.tsx
+++ b/src/components/GuessInput.tsx
@@ -3,9 +3,10 @@ import React from "react";
 
 interface Props {
   addNewGuess: (guess: string) => void;
+  isPlaying: boolean;
 }
 
-function GuessInput({ addNewGuess }: Props) {
+function GuessInput({ addNewGuess, isPlaying }: Props) {
   const [inputGuess, setInputGuess] = React.useState<string>("");
 
   return (
@@ -34,6 +35,7 @@ function GuessInput({ addNewGuess }: Props) {
           const formattedGuess = event.target.value.toUpperCase().trim();
           setInputGuess(formattedGuess);
         }}
+        disabled={!isPlaying}
       />
     </form>
   );


### PR DESCRIPTION
Aggiunto un componente MUI SnackBar che si occupa del render di un Alert che mostra all'utente l'output del game ogni volta che questo si interrompe:
- quando l'utente indovina la parola -> banner positivo (`severity: 'success'`);
- quando finiscono i tentativi -> banner negativo (`severity: 'warning'`).

Per settare un banner, si popola lo stato `alert` con un oggetto che contiene i campi **severity** e **message**.

Ognuno dei banner può essere chiuso cliccando sulla X a destra oppure cliccando in un punto casuale della page fuori da esso. I banner di success e warning, quando vengono chiusi, triggerano il render di un banner informativo (`severity: 'info'`) che invita l'utente a refreshare la pagina per giocare di nuovo.

Nel momento in cui si interrompe la partita, l'input del form viene disabilitato attraverso l'aggiornamento di `isPlaying`, che ora viene passato come prop a `GuessInput`.
